### PR TITLE
Improve new user experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ obj
 *~
 *.swp
 LiveSplit.USB2SNESSplitter.csproj.user
+websocket-sharp.dll
 bin/*
 packages/*

--- a/Component.cs
+++ b/Component.cs
@@ -33,93 +33,6 @@ namespace LiveSplit.UI.Components
             ATTACHED
         }
 
-        internal class Split
-        {
-            public string name { get; set; }
-            public string alias { get; set; }
-            public string address { get; set; }
-            public string value { get; set; }
-            public string type { get; set; }
-            public List<Split> more { get; set; }
-            public List<Split> next { get; set; }
-            public int posToCheck { get; set; } = 0;
-
-            public uint addressint { get { return Convert.ToUInt32(address, 16); } }
-            public uint valueint { get { return Convert.ToUInt32(value, 16); } }
-
-
-            public bool check(uint value, uint word)
-            {
-                bool ret = false;
-                switch (this.type)
-                {
-                    case "bit":
-                        if ((value & this.valueint) != 0) { ret = true; }
-                        break;
-                    case "eq":
-                        if (value == this.valueint) { ret = true; }
-                        break;
-                    case "gt":
-                        if (value > this.valueint) { ret = true; }
-                        break;
-                    case "lt":
-                        if (value < this.valueint) { ret = true; }
-                        break;
-                    case "gte":
-                        if (value >= this.valueint) { ret = true; }
-                        break;
-                    case "lte":
-                        if (value <= this.valueint) { ret = true; }
-                        break;
-                    case "wbit":
-                        if ((word & this.valueint) != 0) { ret = true; }
-                        break;
-                    case "weq":
-                        if (word == this.valueint) { ret = true; }
-                        break;
-                    case "wgt":
-                        if (word > this.valueint) { ret = true; }
-                        break;
-                    case "wlt":
-                        if (word < this.valueint) { ret = true; }
-                        break;
-                    case "wgte":
-                        if (word >= this.valueint) { ret = true; }
-                        break;
-                    case "wlte":
-                        if (word <= this.valueint) { ret = true; }
-                        break;
-                }
-                return ret;
-            }
-
-        }
-
-        class Category
-        {
-            public string name { get; set; }
-            public List<string> splits { get; set; }
-        }
-
-        class Game
-        {
-            public string name { get; set; }
-            public Autostart autostart { get; set; }
-            public Dictionary<String, String> alias { get; set; }
-            public List<Category> categories { get; set; }
-            public List<Split> definitions { get; set; }
-        }
-
-        class Autostart
-        {
-            public string active { get; set; }
-            public string address { get; set; }
-            public string value { get; set; }
-            public string type { get; set; }
-
-            public uint addressint { get { return Convert.ToUInt32(address, 16); } }
-            public uint valueint { get { return Convert.ToUInt32(value, 16); } }
-        }
 
         public string ComponentName => "USB2SNES Auto Splitter";
 
@@ -271,9 +184,9 @@ namespace LiveSplit.UI.Components
             try
             {
                 var jsonStr = File.ReadAllText(_settings.ConfigFile);
-                _game = new System.Web.Script.Serialization.JavaScriptSerializer().Deserialize<Game>(
-                    jsonStr
-                );
+                var serializer = new System.Web.Script.Serialization.JavaScriptSerializer();
+                serializer.RegisterConverters(new[] { new ConfigFileJsonConverter() });
+                _game = serializer.Deserialize<Game>(jsonStr);
             }
             catch (Exception e)
             {

--- a/ComponentSettings.Designer.cs
+++ b/ComponentSettings.Designer.cs
@@ -35,6 +35,11 @@
             this.btnBrowse = new System.Windows.Forms.Button();
             this.btnDetect = new System.Windows.Forms.Button();
             this.chkReset = new System.Windows.Forms.CheckBox();
+            this.errorPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.errorMessage = new System.Windows.Forms.Label();
+            this.errorIcon = new System.Windows.Forms.PictureBox();
+            this.errorPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.errorIcon)).BeginInit();
             this.SuspendLayout();
             // 
             // label1
@@ -100,10 +105,48 @@
             this.chkReset.Text = "Reset SNES on Timer reset";
             this.chkReset.UseVisualStyleBackColor = true;
             // 
+            // errorPanel
+            // 
+            this.errorPanel.AutoSize = true;
+            this.errorPanel.ColumnCount = 2;
+            this.errorPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 38F));
+            this.errorPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.errorPanel.Controls.Add(this.errorIcon, 0, 0);
+            this.errorPanel.Controls.Add(this.errorMessage, 1, 0);
+            this.errorPanel.Location = new System.Drawing.Point(13, 92);
+            this.errorPanel.Name = "errorPanel";
+            this.errorPanel.RowCount = 1;
+            this.errorPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.errorPanel.Size = new System.Drawing.Size(453, 38);
+            this.errorPanel.TabIndex = 7;
+            this.errorPanel.Visible = false;
+            // 
+            // errorMessage
+            // 
+            this.errorMessage.AutoSize = true;
+            this.errorMessage.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.errorMessage.Location = new System.Drawing.Point(41, 0);
+            this.errorMessage.MaximumSize = new System.Drawing.Size(409, 0);
+            this.errorMessage.Name = "errorMessage";
+            this.errorMessage.Size = new System.Drawing.Size(409, 38);
+            this.errorMessage.TabIndex = 1;
+            this.errorMessage.Text = "Error Message";
+            this.errorMessage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // errorIcon
+            // 
+            this.errorIcon.Location = new System.Drawing.Point(3, 3);
+            this.errorIcon.Name = "errorIcon";
+            this.errorIcon.Size = new System.Drawing.Size(32, 32);
+            this.errorIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.errorIcon.TabIndex = 2;
+            this.errorIcon.TabStop = false;
+            // 
             // ComponentSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.errorPanel);
             this.Controls.Add(this.chkReset);
             this.Controls.Add(this.btnDetect);
             this.Controls.Add(this.btnBrowse);
@@ -114,6 +157,9 @@
             this.Name = "ComponentSettings";
             this.Padding = new System.Windows.Forms.Padding(7);
             this.Size = new System.Drawing.Size(476, 512);
+            this.errorPanel.ResumeLayout(false);
+            this.errorPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.errorIcon)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -128,5 +174,8 @@
         private System.Windows.Forms.Button btnBrowse;
         private System.Windows.Forms.Button btnDetect;
         private System.Windows.Forms.CheckBox chkReset;
+        private System.Windows.Forms.TableLayoutPanel errorPanel;
+        private System.Windows.Forms.Label errorMessage;
+        private System.Windows.Forms.PictureBox errorIcon;
     }
 }

--- a/ComponentSettings.cs
+++ b/ComponentSettings.cs
@@ -23,6 +23,8 @@ namespace LiveSplit.UI.Components
             txtComPort.DataBindings.Add("Text", this, "Device", false, DataSourceUpdateMode.OnPropertyChanged);
             txtConfigFile.DataBindings.Add("Text", this, "ConfigFile", false, DataSourceUpdateMode.OnPropertyChanged);
             chkReset.DataBindings.Add("Checked", this, "ResetSNES", false, DataSourceUpdateMode.OnPropertyChanged);
+
+            errorIcon.Image = SystemIcons.Error.ToBitmap();
         }
         public void SetSettings(XmlNode node)
         {
@@ -42,6 +44,12 @@ namespace LiveSplit.UI.Components
         public int GetSettingsHashCode()
         {
             return CreateSettingsNode(null, null);
+        }
+
+        internal void SetError(string message)
+        {
+            errorMessage.Text = message;
+            errorPanel.Visible = !string.IsNullOrEmpty(message);
         }
 
         private int CreateSettingsNode(XmlDocument document, XmlElement parent)

--- a/Config/Autostart.cs
+++ b/Config/Autostart.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace LiveSplit.UI.Components
+{
+    internal class Autostart
+    {
+        public string active { get; set; }
+        public string address { get; set; }
+        public string value { get; set; }
+        public string type { get; set; }
+
+        public uint addressint { get { return Convert.ToUInt32(address, 16); } }
+        public uint valueint { get { return Convert.ToUInt32(value, 16); } }
+    }
+}

--- a/Config/Category.cs
+++ b/Config/Category.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace LiveSplit.UI.Components
+{
+    internal class Category
+    {
+        public string name { get; set; }
+        public List<string> splits { get; set; }
+    }
+}

--- a/Config/ConfigFileJsonConverter.cs
+++ b/Config/ConfigFileJsonConverter.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Web.Script.Serialization;
+
+namespace LiveSplit.UI.Components
+{
+    internal class ConfigFileJsonConverter : JavaScriptConverter
+    {
+        public override IEnumerable<Type> SupportedTypes { get; } = new[] { typeof(Game) };
+
+        public override object Deserialize(IDictionary<string, object> dictionary, Type type, JavaScriptSerializer serializer)
+        {
+            return new Game
+            {
+                name = serializer.ConvertToType<string>(LookupKeys(dictionary, "name", "game")),
+                autostart = serializer.ConvertToType<Autostart>(LookupKeys(dictionary, "autostart")),
+                alias = serializer.ConvertToType<Dictionary<string, string>>(LookupKeys(dictionary, "alias")),
+                categories = serializer.ConvertToType<List<Category>>(LookupKeys(dictionary, "categories")),
+                definitions = serializer.ConvertToType<List<Split>>(LookupKeys(dictionary, "definitions")),
+            };
+        }
+
+        public override IDictionary<string, object> Serialize(object obj, JavaScriptSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static object LookupKeys(IDictionary<string, object> dictionary, params string[] keys)
+        {
+            foreach (string key in keys)
+            {
+                if (dictionary.TryGetValue(key, out object value))
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Config/Game.cs
+++ b/Config/Game.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace LiveSplit.UI.Components
+{
+    internal class Game
+    {
+        public string name { get; set; }
+        public Autostart autostart { get; set; }
+        public Dictionary<string, string> alias { get; set; }
+        public List<Category> categories { get; set; }
+        public List<Split> definitions { get; set; }
+    }
+}

--- a/Config/Split.cs
+++ b/Config/Split.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiveSplit.UI.Components
+{
+    internal class Split
+    {
+        public string name { get; set; }
+        public string address { get; set; }
+        public string value { get; set; }
+        public string type { get; set; }
+        public List<Split> more { get; set; }
+        public List<Split> next { get; set; }
+        public int posToCheck { get; set; } = 0;
+
+        public uint addressint { get { return Convert.ToUInt32(address, 16); } }
+        public uint valueint { get { return Convert.ToUInt32(value, 16); } }
+
+        public bool check(uint value, uint word)
+        {
+            bool ret = false;
+            switch (this.type)
+            {
+                case "bit":
+                    if ((value & this.valueint) != 0) { ret = true; }
+                    break;
+                case "eq":
+                    if (value == this.valueint) { ret = true; }
+                    break;
+                case "gt":
+                    if (value > this.valueint) { ret = true; }
+                    break;
+                case "lt":
+                    if (value < this.valueint) { ret = true; }
+                    break;
+                case "gte":
+                    if (value >= this.valueint) { ret = true; }
+                    break;
+                case "lte":
+                    if (value <= this.valueint) { ret = true; }
+                    break;
+                case "wbit":
+                    if ((word & this.valueint) != 0) { ret = true; }
+                    break;
+                case "weq":
+                    if (word == this.valueint) { ret = true; }
+                    break;
+                case "wgt":
+                    if (word > this.valueint) { ret = true; }
+                    break;
+                case "wlt":
+                    if (word < this.valueint) { ret = true; }
+                    break;
+                case "wgte":
+                    if (word >= this.valueint) { ret = true; }
+                    break;
+                case "wlte":
+                    if (word <= this.valueint) { ret = true; }
+                    break;
+            }
+            return ret;
+        }
+    }
+}

--- a/Factory.cs
+++ b/Factory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using LiveSplit.Model;
 using LiveSplit.UI.Components;
 
@@ -18,5 +19,24 @@ namespace LiveSplit.UI.Components
         public string XMLURL => "";
 
         public IComponent Create(LiveSplitState state) => new USB2SNESComponent(state);
+
+        static Factory()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+            {
+                string resourceName = "LiveSplit." + new AssemblyName(args.Name).Name + ".dll";
+                using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName))
+                {
+                    if (stream != null)
+                    {
+                        byte[] assemblyData = new byte[stream.Length];
+                        stream.Read(assemblyData, 0, assemblyData.Length);
+                        return Assembly.Load(assemblyData);
+                    }
+                }
+
+                return null;
+            };
+        }
     }
 }

--- a/LiveSplit.USB2SNESSplitter.csproj
+++ b/LiveSplit.USB2SNESSplitter.csproj
@@ -63,6 +63,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config\Autostart.cs" />
+    <Compile Include="Config\Category.cs" />
+    <Compile Include="Config\Game.cs" />
+    <Compile Include="Config\ConfigFileJsonConverter.cs" />
+    <Compile Include="Config\Split.cs" />
     <Compile Include="USB2SnesW.cs" />
     <Compile Include="Component.cs" />
     <Compile Include="ComponentSettings.cs">

--- a/LiveSplit.USB2SNESSplitter.csproj
+++ b/LiveSplit.USB2SNESSplitter.csproj
@@ -58,7 +58,8 @@
       <HintPath>..\..\bin\Release\UpdateManager.dll</HintPath>
     </Reference>
     <Reference Include="websocket-sharp">
-      <HintPath>..\websocket-sharp.dll</HintPath>
+      <HintPath>.\websocket-sharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -80,12 +81,14 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <None Include="SuperMetroid.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="alttp-swordup.json" />
+    <None Include="SuperMetroid.json" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="websocket-sharp.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SuperMetroid.json
+++ b/SuperMetroid.json
@@ -1,5 +1,5 @@
 {
-  "game": "Super Metroid",
+  "name": "Super Metroid",
   "autostart": {
     "active": "1",
     "address": "0x0998",

--- a/alttp-swordup.json
+++ b/alttp-swordup.json
@@ -1,5 +1,5 @@
 {
-  "game": "The Legend of Zelda: A link to the past",
+  "name": "The Legend of Zelda: A link to the past",
   "autostart": {
     "active": "1",
     "address": "0x10",


### PR DESCRIPTION
I've put together a few changes that should make it easier for a new user to get the USB2SNES autosplitter up and running:

1. websocket-sharp.dll is now embedded in LiveSplit.USB2SNESSplitter.dll, so it is not necessary to deploy websocket-sharp.dll or websocket-sharp.xml in the release. This removes one potential source of user error when installing the autosplitter.
1. This isn't really related to new user experience, but I noticed a bug in which the `Game` class had a member called `name`, but the included JSON files used the key `game` instead of `name`. I updated the two JSON files to use `name`, but also added a custom JavaScriptConverter that will accept either `game` or `name` as a valid key for the `name` field, so that anyone that is already using the autosplitter does not need to update their JSON to get the fix. While I was at it, I moved all of the config classes that are deserialized from JSON into their own .cs files, in the Config directory.
1. Finally, I added some additional details to messages when there is a problem with the config file, and made it so that those messages are displayed in the Layout Settings dialog for the autosplitter component, as opposed to an error dialog that pops up (sometimes over and over, making it difficult to navigate). I also made it so that the config file will be checked on every update_timer interval as long as there is not a run in progress, so that it picks up changes to the config file, splits, and layout settings without the user having to restart or do anything special.
