### PR TITLE
Support subsplits + DoSplit improvement

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -242,15 +242,17 @@ namespace LiveSplit.UI.Components
                 return false;
             }
 
+            var trimStartChars = new char[] { '-' };
             var unrecognizedSegmentNames = new List<string>();
             foreach (var seg in _state.Run)
             {
-                if (!category.splits.Contains(seg.Name, StringComparer.OrdinalIgnoreCase))
+                var segmentName = seg.Name.TrimStart(trimStartChars);
+                if (!category.splits.Contains(segmentName, StringComparer.OrdinalIgnoreCase))
                 {
                     // Searching into Alias
-                    if (!_game.alias.ContainsKey(seg.Name))
+                    if (!_game.alias.ContainsKey(segmentName))
                     {
-                        unrecognizedSegmentNames.Add(seg.Name);
+                        unrecognizedSegmentNames.Add(segmentName);
                     }
                 }
             }
@@ -275,13 +277,15 @@ namespace LiveSplit.UI.Components
         private void SetSplitList()
         {
             _splits.Clear();
+            var trimStartChars = new char[] { '-' };
             var catSplits = _game.categories.Where(c => c.name.ToLower() == _state.Run.CategoryName.ToLower()).First().splits;
             foreach (var seg in _state.Run)
             {
-                if (catSplits.Contains(seg.Name))
-                    _splits.Add(seg.Name);
+                var segmentName = seg.Name.TrimStart(trimStartChars);
+                if (catSplits.Contains(segmentName))
+                    _splits.Add(segmentName);
                 else
-                    _splits.Add(_game.alias[seg.Name]);
+                    _splits.Add(_game.alias[segmentName]);
             }
         }
 

--- a/Component.cs
+++ b/Component.cs
@@ -342,7 +342,7 @@ namespace LiveSplit.UI.Components
             }
         }
 
-        public async void DoSplit()
+        public async Task DoSplit()
         {
             if (_game.name == "Super Metroid" && _usb2snes.Connected())
             {
@@ -509,7 +509,7 @@ UpdateSplits()
                         {
                             split = split.next[split.posToCheck - 1];
                         }
-                        bool ok = await (doCheckSplit(split));
+                        bool ok = await doCheckSplit(split);
                         if (orignSplit.next != null && ok)
                         {
                             Debug.WriteLine("Next count :" + orignSplit.next.Count + " - Pos to check : " + orignSplit.posToCheck);
@@ -535,7 +535,7 @@ UpdateSplits()
 
                         if (ok)
                         {
-                            DoSplit();
+                            await DoSplit();
                         }
                     } else {
                         connect();


### PR DESCRIPTION
I have a lot of splits, so I thought I would use subsplits.  I found our auto-splitter doesn't support subsplits well.  Let's say I have a subsplit for bombs.  LiveSplit expects subsplits to begin with a hyphen, so it should be "-Bombs".  It will display as "Bombs" without the hyphen, but the actual split name is "-Bombs", which the auto-splitter can't match to the json.  Thus I am changing the auto-splitter to trim leading hyphens off of segment names.

I also found having a lot of consecutive splits can crash the auto-splitter.  If I load up a save file where I have collected a lot of items already, then start the timer, then split once (my first split is the leaving Ceres event), a bunch of splits will happen back-to-back which makes sense (have first missiles, have bombs, have early supers, etc.)  However sometimes LiveSplit crashed.  It complained about the DoSplit method.  Doing a bit of research (https://www.pluralsight.com/guides/returning-void-from-c-async-method), it looks like the DoSplit method should return Task instead of void since it is an async method.  After making this change, I couldn't get it to crash anymore.  I'm not sure if this is the same crash that others were seeing, but still seems like a good improvement.