### PR TITLE
Add support for Super Metroid randomizer boss splits

### DIFF
--- a/SuperMetroid.json
+++ b/SuperMetroid.json
@@ -2483,6 +2483,26 @@
       "address": "0xD883",
       "value": "0x04",
       "type": "bit"
+    },
+    {
+      "name": "Boss 1",
+      "address": "0xD820",
+      "type": "smboss"
+    },
+    {
+      "name": "Boss 2",
+      "address": "0xD820",
+      "type": "smboss"
+    },
+    {
+      "name": "Boss 3",
+      "address": "0xD820",
+      "type": "smboss"
+    },
+    {
+      "name": "Boss 4",
+      "address": "0xD820",
+      "type": "smboss"
     }
   ]
 }


### PR DESCRIPTION
I hate adding special cases, but this seemed like a pretty efficient way to implement a useful feature: few lines of code, minimal overhead. It handles game resets correctly. Tested on a SNES Classic. Let me know if there's anything that should be changed, and I can amend the commit.