### PR TITLE
Fix timer stutter

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -358,7 +358,10 @@ namespace LiveSplit.UI.Components
                 CheckConfig();
             }
 
-            CheckConnection();
+            if (_state.CurrentPhase == TimerPhase.NotRunning || _proto_state != ProtocolState.ATTACHED)
+            {
+                CheckConnection();
+            }
 
             if (_config_state != ConfigState.READY || _proto_state != ProtocolState.ATTACHED)
             {
@@ -485,12 +488,14 @@ namespace LiveSplit.UI.Components
             catch
             {
                 Debug.WriteLine("doCheckSplit: Exception getting address");
+                CheckConnection();
                 return false;
             }
 
             if (data.Count() == 0)
             {
                 Debug.WriteLine("doCheckSplit: Get address failed to return result");
+                CheckConnection();
                 return false;
             }
 


### PR DESCRIPTION
Unrelated to my other PR, I noticed the timer will stutter once per second if the socket is connected. Just a visual glitch, but annoying. This is apparently caused by frequent calls to CheckConnection(). I tried adding a minimum time interval, but this solution (only call CheckConnection as needed) worked best.