### PR TITLE
Prioritize json settings and optimize UI

### DIFF
--- a/Component.cs
+++ b/Component.cs
@@ -358,7 +358,10 @@ namespace LiveSplit.UI.Components
                 CheckConfig();
             }
 
-            CheckConnection();
+            if (_state.CurrentPhase == TimerPhase.NotRunning || _proto_state != ProtocolState.ATTACHED)
+            {
+                CheckConnection();
+            }
 
             if (_config_state != ConfigState.READY || _proto_state != ProtocolState.ATTACHED)
             {
@@ -485,12 +488,14 @@ namespace LiveSplit.UI.Components
             catch
             {
                 Debug.WriteLine("doCheckSplit: Exception getting address");
+                CheckConnection();
                 return false;
             }
 
             if (data.Count() == 0)
             {
                 Debug.WriteLine("doCheckSplit: Get address failed to return result");
+                CheckConnection();
                 return false;
             }
 

--- a/Component.cs
+++ b/Component.cs
@@ -310,7 +310,8 @@ namespace LiveSplit.UI.Components
                 }
                 else
                 {
-                    int ms = (int)data[0][0] + ((int)data[0][1] << 8);
+                    int frames = (int)data[0][0] + ((int)data[0][1] << 8);
+                    int ms = (frames * 1000) / 60;
                     int sec = (int)data[1][0] + ((int)data[1][1] << 8);
                     int min = (int)data[2][0] + ((int)data[2][1] << 8);
                     int hr = (int)data[3][0] + ((int)data[3][1] << 8);
@@ -417,7 +418,7 @@ namespace LiveSplit.UI.Components
         async Task<bool> doCheckSplit(Split split)
         {
             var addressSizePairs = new List<Tuple<uint, uint>>();
-            addressSizePairs.Add(new Tuple<uint, uint>(split.addressInt, 2));// (split.type == "smboss") ? 16 : 2));
+            addressSizePairs.Add(new Tuple<uint, uint>(split.addressInt, 2));
             if (split.more != null)
             {
                 foreach (var moreSplit in split.more)

--- a/Component.cs
+++ b/Component.cs
@@ -287,44 +287,35 @@ namespace LiveSplit.UI.Components
         {
             if (_settings.Config.igt != null && _settings.Config.igt.active == "1" && _usb2snes.Connected())
             {
-                uint[] allAddresses = new uint[] { _settings.Config.igt.framesAddressInt, _settings.Config.igt.secondsAddressInt,
-                                                   _settings.Config.igt.minutesAddressInt, _settings.Config.igt.hoursAddressInt };
-                IEnumerable<uint> validAddresses = allAddresses.Where(address => address > 0);
-                uint startingAddress = validAddresses.Min();
-                uint igtDataSize = (validAddresses.Max() + 2) - startingAddress;
-                if (0 == igtDataSize || igtDataSize > 512)
+                var addressSizePairs = new List<Tuple<uint, uint>>();
+                addressSizePairs.Add(new Tuple<uint, uint>(_settings.Config.igt.framesAddressInt, 2));
+                addressSizePairs.Add(new Tuple<uint, uint>(_settings.Config.igt.secondsAddressInt, 2));
+                addressSizePairs.Add(new Tuple<uint, uint>(_settings.Config.igt.minutesAddressInt, 2));
+                addressSizePairs.Add(new Tuple<uint, uint>(_settings.Config.igt.hoursAddressInt, 2));
+                List<byte[]> data = null;
+                try
                 {
-                    Debug.WriteLine("DoSplit: IGT configuration invalid, skipping it");
+                    data = await _usb2snes.GetAddress(addressSizePairs);
+                }
+                catch
+                {
+                    Debug.WriteLine("DoSplit: Exception getting address");
+                    _model.Split();
+                    return;
+                }
+
+                if ((null == data) || (data.Count != addressSizePairs.Count))
+                {
+                    Debug.WriteLine("DoSplit: Get address failed to return result");
                 }
                 else
                 {
-                    byte[] data;
-                    try
-                    {
-                        data = await _usb2snes.GetAddress((0xF50000 + startingAddress), igtDataSize);
-                    }
-                    catch
-                    {
-                        Debug.WriteLine("DoSplit: Exception getting address");
-                        _model.Split();
-                        return;
-                    }
-
-                    if (data.Count() == 0)
-                    {
-                        Debug.WriteLine("DoSplit: Get address failed to return result");
-                    }
-                    else
-                    {
-                        Func<uint, int> readIgt = (address) =>
-                                (0 == address) ? 0 : (data[address - startingAddress] + (data[(address + 1) - startingAddress] << 8));
-                        int ms = (readIgt(_settings.Config.igt.framesAddressInt) * 1000) / 60;
-                        int sec = readIgt(_settings.Config.igt.secondsAddressInt);
-                        int min = readIgt(_settings.Config.igt.minutesAddressInt);
-                        int hr = readIgt(_settings.Config.igt.hoursAddressInt);
-                        var gt = new TimeSpan(0, hr, min, sec, ms);
-                        _state.SetGameTime(gt);
-                    }
+                    int ms = (int)data[0][0] + ((int)data[0][1] << 8);
+                    int sec = (int)data[1][0] + ((int)data[1][1] << 8);
+                    int min = (int)data[2][0] + ((int)data[2][1] << 8);
+                    int hr = (int)data[3][0] + ((int)data[3][1] << 8);
+                    var gt = new TimeSpan(0, hr, min, sec, ms);
+                    _state.SetGameTime(gt);
                 }
             }
             _model.Split();
@@ -374,64 +365,9 @@ namespace LiveSplit.UI.Components
                 {
                     if (_settings.Config.autostart != null && _settings.Config.autostart.active == "1")
                     {
-                        byte[] data;
-                        try
+                        if (await doCheckSplitWithNext(_settings.Config.autostart.GetSplit()))
                         {
-                            data = await _usb2snes.GetAddress((0xF50000 + _settings.Config.autostart.addressInt), (uint)2);
-                        }
-                        catch
-                        {
-                            Debug.WriteLine("UpdateSplits: Exception getting address");
-                            return;
-                        }
-
-                        if (data.Count() == 0)
-                        {
-                            Debug.WriteLine("UpdateSplits: Get address failed to return result");
-                            return;
-                        }
-
-                        uint value = (uint)data[0];
-                        uint word = (uint)(data[0] + (data[1] << 8));
-
-                        switch (_settings.Config.autostart.type)
-                        {
-                            case "bit":
-                                if ((value & _settings.Config.autostart.valueInt) != 0) { _model.Start(); }
-                                break;
-                            case "eq":
-                                if (value == _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "gt":
-                                if (value > _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "lt":
-                                if (value < _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "gte":
-                                if (value >= _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "lte":
-                                if (value <= _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "wbit":
-                                if ((word & _settings.Config.autostart.valueInt) != 0) { _model.Start(); }
-                                break;
-                            case "weq":
-                                if (word == _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "wgt":
-                                if (word > _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "wlt":
-                                if (word < _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "wgte":
-                                if (word >= _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
-                            case "wlte":
-                                if (word <= _settings.Config.autostart.valueInt) { _model.Start(); }
-                                break;
+                            _model.Start();
                         }
                     }
                 }
@@ -439,38 +375,7 @@ namespace LiveSplit.UI.Components
                 {
                     var splitName = _splits[_state.CurrentSplitIndex];
                     var split = _settings.Config.definitions.Where(x => x.name == splitName).First();
-                    var orignSplit = split;
-                    if (split.next != null && split.posToCheck != 0)
-                    {
-                        split = split.next[split.posToCheck - 1];
-                    }
-                    bool ok = await doCheckSplit(split);
-                    if (orignSplit.next != null && ok)
-                    {
-                        Debug.WriteLine("Next count :" + orignSplit.next.Count + " - Pos to check : " + orignSplit.posToCheck);
-                        if (orignSplit.posToCheck < orignSplit.next.Count())
-                        {
-                            orignSplit.posToCheck++;
-                            ok = false;
-                        }
-                        else
-                        {
-                            orignSplit.posToCheck = 0;
-                        }
-                    }
-                    if (split.more != null)
-                    {
-                        foreach (var moreSplit in split.more)
-                        {
-                            if (!ok)
-                            {
-                                break;
-                            }
-                            ok = ok && await doCheckSplit(moreSplit);
-                        }
-                    }
-
-                    if (ok)
+                    if (await doCheckSplitWithNext(split))
                     {
                         await DoSplit();
                     }
@@ -478,12 +383,52 @@ namespace LiveSplit.UI.Components
             }
         }
 
+        async Task<bool> doCheckSplitWithNext(Split split)
+        {
+            if (split.next == null)
+            {
+                return await doCheckSplit(split);
+            }
+
+            bool ok = false;
+            if (split.posToCheck > 0)
+            {
+                ok = await doCheckSplit(split.next[split.posToCheck - 1]);
+            }
+            else
+            {
+                ok = await doCheckSplit(split);
+            }
+            if (ok)
+            {
+                if (split.posToCheck < split.next.Count())
+                {
+                    split.posToCheck++;
+                    ok = false;
+                }
+                else
+                {
+                    split.posToCheck = 0;
+                }
+            }
+            return ok;
+        }
+
         async Task<bool> doCheckSplit(Split split)
         {
-            byte[] data;
+            var addressSizePairs = new List<Tuple<uint, uint>>();
+            addressSizePairs.Add(new Tuple<uint, uint>(split.addressInt, 2));// (split.type == "smboss") ? 16 : 2));
+            if (split.more != null)
+            {
+                foreach (var moreSplit in split.more)
+                {
+                    addressSizePairs.Add(new Tuple<uint, uint>(moreSplit.addressInt, 2));
+                }
+            }
+            List<byte[]> data = null;
             try
             {
-                data = await _usb2snes.GetAddress((0xF50000 + split.addressInt), (uint)2);
+                data = await _usb2snes.GetAddress(addressSizePairs);
             }
             catch
             {
@@ -492,17 +437,29 @@ namespace LiveSplit.UI.Components
                 return false;
             }
 
-            if (data.Count() == 0)
+            if ((null == data) || (data.Count != addressSizePairs.Count))
             {
                 Debug.WriteLine("doCheckSplit: Get address failed to return result");
                 CheckConnection();
                 return false;
             }
 
-            uint value = (uint)data[0];
-            uint word = (uint)(data[0] + (data[1] << 8));
-            Debug.WriteLine("Address checked : " + split.address + " - value : " + value);
-            return split.check(value, word);
+            uint value = (uint)data[0][0];
+            uint word = value + ((uint)data[0][1] << 8);
+            bool result = split.check(value, word);
+            if (result && (split.more != null))
+            {
+                int dataIndex = 1;
+                foreach (var moreSplit in split.more)
+                {
+                    value = (uint)data[dataIndex][0];
+                    word = value + ((uint)data[dataIndex][1] << 8);
+                    if (!moreSplit.check(value, word))
+                        return false;
+                    dataIndex++;
+                }
+            }
+            return result;
         }
 
         public void DrawHorizontal(Graphics g, LiveSplitState state, float height, Region clipRegion)

--- a/Config/Autostart.cs
+++ b/Config/Autostart.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace LiveSplit.UI.Components
 {
@@ -8,8 +9,23 @@ namespace LiveSplit.UI.Components
         public string address { get; set; }
         public string value { get; set; }
         public string type { get; set; }
+        public List<Split> more { get; set; }
+        public List<Split> next { get; set; }
 
-        public uint addressInt { get { return Convert.ToUInt32(address, 16); } }
-        public uint valueInt { get { return Convert.ToUInt32(value, 16); } }
+        public Split GetSplit()
+        {
+            if (split == null)
+            {
+                split = new Split();
+                split.address = address;
+                split.value = value;
+                split.type = type;
+                split.more = more;
+                split.next = next;
+            }
+            return split;
+        }
+
+        private Split split = null;
     }
 }

--- a/Config/ConfigFileJsonConverter.cs
+++ b/Config/ConfigFileJsonConverter.cs
@@ -10,7 +10,7 @@ namespace LiveSplit.UI.Components
 
         public override object Deserialize(IDictionary<string, object> dictionary, Type type, JavaScriptSerializer serializer)
         {
-            return new Game
+            var game = new Game
             {
                 name = serializer.ConvertToType<string>(LookupKeys(dictionary, "name", "game")),
                 autostart = serializer.ConvertToType<Autostart>(LookupKeys(dictionary, "autostart")),
@@ -18,6 +18,12 @@ namespace LiveSplit.UI.Components
                 alias = serializer.ConvertToType<Dictionary<string, string>>(LookupKeys(dictionary, "alias")),
                 definitions = serializer.ConvertToType<List<Split>>(LookupKeys(dictionary, "definitions")),
             };
+            game.autostart.GetSplit().validate();
+            foreach (var split in game.definitions)
+            {
+               split.validate();
+            }
+            return game;
         }
 
         public override IDictionary<string, object> Serialize(object obj, JavaScriptSerializer serializer)

--- a/Config/Split.cs
+++ b/Config/Split.cs
@@ -60,5 +60,34 @@ namespace LiveSplit.UI.Components
             }
             return ret;
         }
+
+        public void validate()
+        {
+            if (more != null)
+            {
+                foreach (var moreSplit in more)
+                {
+                    if (moreSplit.more != null)
+                    {
+                        throw new NotSupportedException("Nested 'more' splits are not supported");
+                    }
+                    if (moreSplit.next != null)
+                    {
+                        throw new NotSupportedException("Nested 'next' splits are not supported");
+                    }
+                }
+            }
+            if (next != null)
+            {
+                foreach (var nextSplit in next)
+                {
+                    if (nextSplit.next != null)
+                    {
+                        throw new NotSupportedException("Nested 'next' splits are not supported");
+                    }
+                    nextSplit.validate();
+                }
+            }
+        }
     }
 }

--- a/SuperMetroid.json
+++ b/SuperMetroid.json
@@ -3,8 +3,15 @@
   "autostart": {
     "active": "1",
     "address": "0x0998",
-    "value": "0x1F",
-    "type": "eq"
+    "value": "0x02",
+    "type": "eq",
+    "next": [
+      {
+        "address": "0x0DE2",
+        "value": "0x0C",
+        "type": "eq"
+      }
+    ]
   },
   "igt": {
     "active": "0",


### PR DESCRIPTION
I believe the edit splits UI is faster than before, and the first time you visit the layout settings is fast.  For whatever reason when you visit layout settings a second time, the tab is still very slow to load when you have a lot of splits.  Hopefully someone can improve that in the future.

I adjusted logic to prioritize the json over previously stored settings, just to make sure if your split name matches a name in the json then that is always selected.  I also fixed a mistake involving subsplits.  Previously I added support for subsplits, but I wasn't saving them properly.  This issue only affected subsplits.