### PR TITLE
Change default port

### DIFF
--- a/USB2SnesW.cs
+++ b/USB2SnesW.cs
@@ -85,7 +85,7 @@ namespace USB2SnesW
         public USB2SnesW()
         {
             Console.WriteLine("Creating USB2Snes");
-            ws = new WebSocket("ws://localhost:8080");
+            ws = new WebSocket("ws://localhost:23074");
             Console.WriteLine(ws);
         }
 


### PR DESCRIPTION
Update the default port to 23074 from 8080.

Both (q)usb2snes and SNI have always listened on both 8080 and 23074, but SNI has recently deprecated use of port 8080. With no way to customize the port, unless I'm missing something, it makes sense to change the default to prevent new users having issues.